### PR TITLE
Keep the tunnel loss estimate moving when the tunnel stalls

### DIFF
--- a/internal/client/tunnel_loss.go
+++ b/internal/client/tunnel_loss.go
@@ -35,8 +35,17 @@ func (m *tunnelLossMeter) recordData() {
 	}
 }
 
+// A window is a window of fresh data, so retransmits normally just accumulate
+// into the next flush. They also close the window on their own once there are
+// a window's worth of them, which is the stalled case: a tunnel losing enough
+// to choke sends little new data while resends pile up, so it never reached a
+// data-driven flush and the estimate stayed frozen at whatever the last healthy
+// period measured. Adaptive duplication reads this estimate, so without this it
+// could not rise during exactly the loss it exists to answer.
 func (m *tunnelLossMeter) recordResend() {
-	m.windowResends.Add(1)
+	if m.windowResends.Add(1) >= tunnelLossWindow {
+		m.flush()
+	}
 }
 
 func (m *tunnelLossMeter) flush() {

--- a/internal/client/tunnel_loss_stall_test.go
+++ b/internal/client/tunnel_loss_stall_test.go
@@ -1,0 +1,39 @@
+package client
+
+import "testing"
+
+// A tunnel that is losing badly sends little new data and many retransmits, so
+// a purely data-driven window never closes and the estimate freezes. Adaptive
+// duplication reads that estimate and is meant to raise the copy count exactly
+// then, so the meter has to keep moving in this regime.
+func TestTunnelLossMeterUpdatesWhenDataStalls(t *testing.T) {
+	var m tunnelLossMeter
+
+	// A healthy stretch first, so a stale reading would be a low one.
+	for i := 0; i < tunnelLossWindow; i++ {
+		m.recordData()
+	}
+	if got := m.perMille(); got != 0 {
+		t.Fatalf("clean window should measure no loss, got %d", got)
+	}
+
+	// The stall: a trickle of new data against a window's worth of resends.
+	for i := 0; i < tunnelLossWindow; i++ {
+		m.recordResend()
+		if i%20 == 0 {
+			m.recordData()
+		}
+	}
+	got := m.perMille()
+	if got == 0 {
+		t.Fatal("loss estimate stayed frozen while the tunnel was retransmitting")
+	}
+	if got < 800 {
+		t.Fatalf("expected a heavy resend ratio, got %d per mille", got)
+	}
+
+	// And that estimate has to move duplication off its floor.
+	if copies := duplicationForLoss(1, float64(got)/1000.0, 0.95); copies <= 1 {
+		t.Fatalf("duplication stayed at the floor under %d per mille loss", got)
+	}
+}


### PR DESCRIPTION
## What changed

- retransmits now close the loss window on their own once there is a window's worth of them
- a window is still a window of fresh data in the normal case, so the measured ratio is unchanged for healthy traffic

## Why

`tunnelLossMeter` closed its window only on fresh `STREAM_DATA`. A tunnel losing badly does the opposite of that: new data slows to a trickle while `STREAM_RESEND` piles up, so the window never completed and `lastPerMille` stayed frozen at whatever the last healthy period measured — usually zero.

`adaptiveDuplicationCount` derives the copy count from that estimate. With the floor at one copy, which is what the speed preset configures, duplication could not rise during exactly the loss it exists to answer: the tunnel sat at a single copy per packet while retransmitting nearly everything.

## Validation

- new test drives a healthy window, then a stall of mostly retransmits, and asserts the estimate moves and that `duplicationForLoss` lifts the count off its floor
- the existing `TestTunnelLossMeter_UploadRetransmitRate` still passes unchanged, which is the check that the healthy-traffic ratio was not redefined
- `go build ./...`, `go vet ./...`, and `go test ./...` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)